### PR TITLE
Updated documentation to switch meaning of -r and -c.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ or
 photomosaic-core.exe -i sample.jpg -r 145 -c 100 -s 10
 
 -i                                      path to the original picture that shall be recreated
--r                                      number of thumbnails to create per row
--c                                      number of thumbnails to create per column
+-r                                      number of rows in output image
+-c                                      number of columns in output image
 -m          (default = ".\material")    path to the material folder
 -s          (default = 1)               output image size = input image size * scale
 -vs         (default = 5000)            sampling video image interval (ms), only need be set if the material include video files

--- a/core/src/photomosaic-core.py
+++ b/core/src/photomosaic-core.py
@@ -441,8 +441,8 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "-input-image", dest="img", default="", help="input image path")
-    parser.add_argument("-r", "-row", dest="row", default=0, help="number of thumbnails to create per row")
-    parser.add_argument("-c", "-col", dest="col", default=0, help="number of thumbnails to create per col")
+    parser.add_argument("-r", "-row", dest="row", default=0, help="number of rows in output image")
+    parser.add_argument("-c", "-col", dest="col", default=0, help="number of columns in output image")
     parser.add_argument("-m", "-material", dest="material", default="", help="material folder path")
     parser.add_argument("-s", "-scale", dest="scale", default=1.0, help="output image size = input image size * scale")
     parser.add_argument("-vs", "-video-sampling-ms", dest="video_sampling_ms", default=5000, help="sampling video image interval (ms)")


### PR DESCRIPTION
I think the current documentation is misleading. 

`thumbnails to create per row` means "number of columns", but in fact this controls the number of rows (and vice versa).

I have kept the arguments the same but updated the documentation.